### PR TITLE
DOC Fix broken scipy link

### DIFF
--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -153,7 +153,7 @@ A continuous log-uniform random variable is available through
 log-spaced parameters. For example to specify ``C`` above, ``loguniform(1,
 100)`` can be used instead of ``[1, 10, 100]`` or ``np.logspace(0, 2,
 num=1000)``. This is an alias to SciPy's `stats.reciprocal
-<https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.reciprocal.html>`_.
+<https://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.stats.reciprocal.html>`_.
 
 Mirroring the example above in grid search, we can specify a continuous random
 variable that is log-uniformly distributed between ``1e0`` and ``1e3``::


### PR DESCRIPTION
#### Reference Issues/PRs



#### What does this implement/fix? Explain your changes.

The link <https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.reciprocal.html> vas broken, replaced it with <https://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.stats.reciprocal.html>.

As the `scipy.stats.reciprocal` disappeared in new version of `scipy`, I changed the link to an old version of the doc.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
